### PR TITLE
Add Tkinter POS prototype with SQLite backend

### DIFF
--- a/pos_app/README.md
+++ b/pos_app/README.md
@@ -1,0 +1,51 @@
+# Kapipang Blends POS Prototype
+
+This repository now includes a Python/Tkinter prototype that lays the
+foundation for the offline Kapipang Blends point-of-sale (POS) system.
+It focuses on two key objectives:
+
+1. Prepare the complete SQLite schema required by the specification.
+2. Provide a role-aware Tkinter shell that can be expanded into the full
+   experience (sales terminal, inventory, analytics, attendance, etc.).
+
+## Features
+
+- **Offline SQLite database** with the required tables (users, inventory,
+  sales, sale items, customers, attendance, activity logs, and store
+  settings).
+- **Role-based authentication** with password hashing. Default
+  credentials are created on first run (owner/manager/staff with
+  `*123` passwords). As soon as a user logs in, their password is
+  upgraded to a salted SHA-256 hash stored in the database.
+- **Tkinter interface** featuring a login window and dashboard. The
+  dashboard dynamically enables tabs depending on the logged-in user's
+  role to demonstrate the access model.
+- **Attendance logging** prototype which records clock in/out actions and
+  pushes them to the activity log.
+- **Activity log viewer** available to the owner and manager roles.
+
+## Running the prototype
+
+```bash
+python -m pos_app.main
+```
+
+The first execution will create the `kapipang_pos.db` SQLite database in
+`pos_app/`. Subsequent runs will reuse the same data file.
+
+## Next steps
+
+This code purposefully keeps the UI lightweight so the business logic
+can be iteratively implemented. Suggested areas to build next:
+
+- Flesh out the Sales & Billing tab with product buttons, order tables,
+  payment handling, loyalty redemptions, and receipt printing.
+- Extend the Inventory tab to add/edit products, trigger low stock
+  notifications, and manage expiration tracking.
+- Implement analytics charts (Matplotlib) and report export tools.
+- Finalise customer loyalty workflows and birthday promotions.
+- Harden security (password reset flows, void password management, idle
+  timeout enforcement).
+
+The provided structure should help accelerate the remaining work while
+keeping the application fully offline-ready.

--- a/pos_app/__init__.py
+++ b/pos_app/__init__.py
@@ -1,0 +1,4 @@
+"""Kapipang Blends POS prototype package."""
+from .main import POSApplication, main
+
+__all__ = ["POSApplication", "main"]

--- a/pos_app/auth.py
+++ b/pos_app/auth.py
@@ -1,0 +1,84 @@
+"""Authentication helpers for the Kapipang Blends POS system."""
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from .database import db, DatabaseManager
+
+
+@dataclass
+class User:
+    id: int
+    username: str
+    role: str
+
+
+def _hash_password(password: str, salt: str) -> str:
+    return hashlib.sha256(f"{salt}:{password}".encode()).hexdigest()
+
+
+def create_user(username: str, password: str, role: str, *, manager: DatabaseManager | None = None) -> None:
+    if role not in {"owner", "manager", "staff"}:
+        raise ValueError("Invalid role")
+
+    manager = manager or db
+    salt = secrets.token_hex(16)
+    hashed = _hash_password(password, salt)
+    manager.execute(
+        "INSERT INTO users (username, password, role) VALUES (?, ?, ?)",
+        (username, f"{salt}${hashed}", role),
+    )
+
+
+def verify_credentials(username: str, password: str, *, manager: DatabaseManager | None = None) -> Optional[User]:
+    manager = manager or db
+    with manager.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id, username, password, role FROM users WHERE username = ?", (username,))
+        row = cursor.fetchone()
+        if not row:
+            return None
+
+        stored = row["password"]
+        if "$" not in stored:
+            # Legacy plain-text password, upgrade on the fly
+            hashed = _hash_password(password, salt := secrets.token_hex(16))
+            cursor.execute(
+                "UPDATE users SET password = ? WHERE id = ?",
+                (f"{salt}${hashed}", row["id"]),
+            )
+            conn.commit()
+            return User(id=row["id"], username=row["username"], role=row["role"])
+
+        salt, digest = stored.split("$", 1)
+        if _hash_password(password, salt) != digest:
+            return None
+        return User(id=row["id"], username=row["username"], role=row["role"])
+
+
+def log_activity(user: User, action: str, details: str = "", *, manager: DatabaseManager | None = None) -> None:
+    manager = manager or db
+    timestamp = datetime.now().isoformat(timespec="seconds")
+    manager.execute(
+        "INSERT INTO activity_logs (user_id, action, details, timestamp) VALUES (?, ?, ?, ?)",
+        (user.id, action, details, timestamp),
+    )
+
+
+def ensure_default_passwords_hashed() -> None:
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id, password FROM users")
+        updates: list[tuple[str, int]] = []
+        for row in cursor.fetchall():
+            if "$" in row["password"]:
+                continue
+            salt = secrets.token_hex(16)
+            updates.append((f"{salt}${_hash_password(row['password'], salt)}", row["id"]))
+        if updates:
+            cursor.executemany("UPDATE users SET password = ? WHERE id = ?", updates)
+            conn.commit()

--- a/pos_app/database.py
+++ b/pos_app/database.py
@@ -1,0 +1,164 @@
+"""Database utilities for Kapipang Blends POS system.
+
+This module centralises creation of the SQLite database and exposes
+helpers for querying data across the application.  Everything is kept
+self-contained so the application can run entirely offline.
+"""
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from pathlib import Path
+from typing import Generator, Iterable
+
+DB_PATH = Path(__file__).with_name("kapipang_pos.db")
+
+
+class DatabaseManager:
+    """Handle connections and schema management for the POS system."""
+
+    def __init__(self, path: Path | str | None = None) -> None:
+        self.db_path = Path(path) if path else DB_PATH
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialise()
+
+    def _initialise(self) -> None:
+        with self.get_connection() as conn:
+            self._create_tables(conn)
+            self._ensure_default_users(conn)
+
+    @staticmethod
+    def _create_tables(conn: sqlite3.Connection) -> None:
+        cursor = conn.cursor()
+        cursor.executescript(
+            """
+            PRAGMA foreign_keys = ON;
+
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE NOT NULL,
+                password TEXT NOT NULL,
+                role TEXT NOT NULL CHECK(role IN ('owner', 'manager', 'staff'))
+            );
+
+            CREATE TABLE IF NOT EXISTS customers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                contact TEXT,
+                loyalty_points INTEGER DEFAULT 0,
+                birthday TEXT,
+                favorites TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS inventory (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                category TEXT NOT NULL,
+                sku TEXT UNIQUE NOT NULL,
+                cogs REAL NOT NULL,
+                selling_price REAL NOT NULL,
+                stock_quantity INTEGER NOT NULL DEFAULT 0,
+                expiration_date TEXT,
+                low_stock_threshold INTEGER DEFAULT 0,
+                UNIQUE(name, sku)
+            );
+
+            CREATE TABLE IF NOT EXISTS sales (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                customer_id INTEGER,
+                total_amount REAL NOT NULL,
+                payment_method TEXT NOT NULL,
+                discount REAL DEFAULT 0,
+                loyalty_points_used INTEGER DEFAULT 0,
+                loyalty_points_earned INTEGER DEFAULT 0,
+                feedback_qr TEXT,
+                timestamp TEXT NOT NULL,
+                FOREIGN KEY (customer_id) REFERENCES customers(id)
+            );
+
+            CREATE TABLE IF NOT EXISTS sale_items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                sale_id INTEGER NOT NULL,
+                inventory_id INTEGER NOT NULL,
+                quantity INTEGER NOT NULL,
+                price REAL NOT NULL,
+                FOREIGN KEY (sale_id) REFERENCES sales(id) ON DELETE CASCADE,
+                FOREIGN KEY (inventory_id) REFERENCES inventory(id)
+            );
+
+            CREATE TABLE IF NOT EXISTS attendance (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                staff_id INTEGER NOT NULL,
+                time_in TEXT NOT NULL,
+                time_out TEXT,
+                role TEXT NOT NULL,
+                UNIQUE(staff_id, date(time_in)),
+                FOREIGN KEY (staff_id) REFERENCES users(id)
+            );
+
+            CREATE TABLE IF NOT EXISTS activity_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                action TEXT NOT NULL,
+                details TEXT,
+                timestamp TEXT NOT NULL,
+                FOREIGN KEY (user_id) REFERENCES users(id)
+            );
+
+            CREATE TABLE IF NOT EXISTS settings (
+                id INTEGER PRIMARY KEY CHECK(id = 1),
+                store_name TEXT DEFAULT 'Kapipang Blends',
+                theme TEXT DEFAULT 'light',
+                discount_presets TEXT,
+                loyalty_points_ratio REAL DEFAULT 0.01,
+                tax_rate REAL DEFAULT 0.0,
+                service_charge REAL DEFAULT 0.0,
+                receipt_footer TEXT DEFAULT 'Thank you for visiting Kapipang Blends!',
+                idle_timeout INTEGER DEFAULT 300
+            );
+            """
+        )
+        conn.commit()
+
+    @staticmethod
+    def _ensure_default_users(conn: sqlite3.Connection) -> None:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM users")
+        (count,) = cursor.fetchone()
+        if count:
+            return
+
+        cursor.executemany(
+            "INSERT INTO users (username, password, role) VALUES (?, ?, ?)",
+            [
+                ("owner", "owner123", "owner"),
+                ("manager", "manager123", "manager"),
+                ("staff", "staff123", "staff"),
+            ],
+        )
+        cursor.execute("INSERT OR IGNORE INTO settings (id) VALUES (1)")
+        conn.commit()
+
+    @contextlib.contextmanager
+    def get_connection(self) -> Generator[sqlite3.Connection, None, None]:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def query(self, query: str, params: Iterable | None = None) -> list[sqlite3.Row]:
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, params or [])
+            return cursor.fetchall()
+
+    def execute(self, query: str, params: Iterable | None = None) -> None:
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(query, params or [])
+            conn.commit()
+
+
+db = DatabaseManager()

--- a/pos_app/main.py
+++ b/pos_app/main.py
@@ -1,0 +1,46 @@
+"""Entry point for the Kapipang Blends POS prototype."""
+from __future__ import annotations
+
+import tkinter as tk
+from .auth import User, ensure_default_passwords_hashed, log_activity
+from .ui.dashboard import Dashboard
+from .ui.login import LoginWindow
+
+
+class POSApplication(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Kapipang Blends POS")
+        self.geometry("900x600")
+        self.minsize(900, 600)
+        self.style = None
+        self.user: User | None = None
+
+        ensure_default_passwords_hashed()
+        self.after(0, self._show_login)
+
+    def _show_login(self) -> None:
+        self.withdraw()
+        LoginWindow(self, self._on_login_success)
+
+    def _on_login_success(self, user: User) -> None:
+        self.user = user
+        self.deiconify()
+        self._render_dashboard()
+        log_activity(user, "login", "User signed in")
+
+    def _render_dashboard(self) -> None:
+        for child in self.winfo_children():
+            child.destroy()
+        if not self.user:
+            return
+        dashboard = Dashboard(self, self.user)
+        dashboard.pack(fill=tk.BOTH, expand=True)
+
+
+def main() -> None:
+    POSApplication().mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pos_app/ui/dashboard.py
+++ b/pos_app/ui/dashboard.py
@@ -1,0 +1,133 @@
+"""Dashboard container that swaps views based on the logged in user's role."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+from datetime import datetime
+
+from ..auth import User
+from ..database import db
+
+
+class Dashboard(ttk.Frame):
+    def __init__(self, master: tk.Misc, user: User) -> None:
+        super().__init__(master)
+        self.user = user
+        self.notebook = ttk.Notebook(self)
+        self.notebook.pack(fill=tk.BOTH, expand=True)
+
+        self._populate_tabs()
+
+    def _populate_tabs(self) -> None:
+        role = self.user.role
+        self._add_sales_tab()
+        if role in {"owner", "manager"}:
+            self._add_inventory_tab()
+            self._add_reports_tab()
+            self._add_activity_tab()
+        if role in {"owner", "manager", "staff"}:
+            self._add_attendance_tab()
+        if role == "owner":
+            self._add_settings_tab()
+
+    def _add_sales_tab(self) -> None:
+        frame = ttk.Frame(self.notebook)
+        self.notebook.add(frame, text="Sales & Billing")
+        ttk.Label(frame, text="Sales terminal placeholder", font=("Helvetica", 14)).pack(pady=12)
+        ttk.Label(
+            frame,
+            text=(
+                "This prototype initialises the offline database and locks down access\n"
+                "based on user roles. Extend this tab with the ordering interface,\n"
+                "payment processing and receipt generation logic."
+            ),
+            justify=tk.CENTER,
+        ).pack(pady=12)
+
+    def _add_inventory_tab(self) -> None:
+        frame = ttk.Frame(self.notebook)
+        self.notebook.add(frame, text="Inventory")
+        ttk.Label(frame, text="Inventory management placeholder", font=("Helvetica", 14)).pack(pady=12)
+        ttk.Button(frame, text="View Items", command=self._show_inventory_records).pack(pady=8)
+        self.inventory_list = tk.Listbox(frame, height=10)
+        self.inventory_list.pack(fill=tk.BOTH, expand=True, padx=12, pady=(0, 12))
+
+    def _show_inventory_records(self) -> None:
+        self.inventory_list.delete(0, tk.END)
+        rows = db.query(
+            "SELECT name, sku, stock_quantity, expiration_date FROM inventory ORDER BY name"
+        )
+        for row in rows:
+            expiry = row["expiration_date"] or "N/A"
+            self.inventory_list.insert(
+                tk.END, f"{row['name']} ({row['sku']}) - Stock: {row['stock_quantity']} - Exp: {expiry}"
+            )
+
+    def _add_reports_tab(self) -> None:
+        frame = ttk.Frame(self.notebook)
+        self.notebook.add(frame, text="Reports")
+        ttk.Label(frame, text="Reports & Analytics placeholder", font=("Helvetica", 14)).pack(pady=12)
+        ttk.Label(
+            frame,
+            text=(
+                "Implement dashboards, loyalty insights, and offline charts in this tab."
+            ),
+        ).pack(pady=8)
+
+    def _add_activity_tab(self) -> None:
+        frame = ttk.Frame(self.notebook)
+        self.notebook.add(frame, text="Activity Logs")
+        ttk.Label(frame, text="Recent actions", font=("Helvetica", 14, "bold")).pack(pady=12)
+        self.activity_list = tk.Listbox(frame, height=12)
+        self.activity_list.pack(fill=tk.BOTH, expand=True, padx=12, pady=(0, 12))
+        self._refresh_activity()
+
+    def _refresh_activity(self) -> None:
+        if not hasattr(self, "activity_list"):
+            return
+        self.activity_list.delete(0, tk.END)
+        rows = db.query(
+            "SELECT action, details, timestamp FROM activity_logs ORDER BY timestamp DESC LIMIT 20"
+        )
+        for row in rows:
+            self.activity_list.insert(tk.END, f"[{row['timestamp']}] {row['action']} - {row['details']}")
+
+    def _add_attendance_tab(self) -> None:
+        frame = ttk.Frame(self.notebook)
+        self.notebook.add(frame, text="Attendance")
+        ttk.Label(frame, text="Attendance tracking placeholder", font=("Helvetica", 14)).pack(pady=12)
+        ttk.Button(frame, text="Clock in", command=lambda: self._register_attendance("in")).pack(pady=6)
+        ttk.Button(frame, text="Clock out", command=lambda: self._register_attendance("out")).pack(pady=6)
+
+    def _register_attendance(self, action: str) -> None:
+        timestamp = datetime.now().isoformat(timespec="seconds")
+        if action == "in":
+            db.execute(
+                """
+                INSERT OR IGNORE INTO attendance (staff_id, time_in, role)
+                VALUES (?, ?, ?)
+                """,
+                (self.user.id, timestamp, self.user.role),
+            )
+        else:
+            db.execute(
+                """
+                UPDATE attendance SET time_out = ?
+                WHERE staff_id = ? AND date(time_in) = date('now')
+                """,
+                (timestamp, self.user.id),
+            )
+        self._log_action(f"Clocked {action}")
+
+    def _add_settings_tab(self) -> None:
+        frame = ttk.Frame(self.notebook)
+        self.notebook.add(frame, text="Settings")
+        ttk.Label(frame, text="Store settings placeholder", font=("Helvetica", 14)).pack(pady=12)
+        ttk.Label(frame, text="Use this area to configure themes, discounts, and receipt messages.").pack(pady=8)
+
+    def _log_action(self, message: str) -> None:
+        db.execute(
+            "INSERT INTO activity_logs (user_id, action, details, timestamp) VALUES (?, ?, ?, datetime('now'))",
+            (self.user.id, "attendance", message),
+        )
+        self._refresh_activity()

--- a/pos_app/ui/login.py
+++ b/pos_app/ui/login.py
@@ -1,0 +1,60 @@
+"""Tkinter login window for Kapipang Blends POS."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox
+
+from ..auth import verify_credentials
+
+
+class LoginWindow(tk.Toplevel):
+    def __init__(self, master: tk.Misc, on_success) -> None:
+        super().__init__(master)
+        self.title("Kapipang Blends POS - Login")
+        self.resizable(False, False)
+        self.protocol("WM_DELETE_WINDOW", self._on_close)
+        self.on_success = on_success
+
+        self.username_var = tk.StringVar()
+        self.password_var = tk.StringVar()
+
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        container = tk.Frame(self, padx=24, pady=24)
+        container.pack(fill=tk.BOTH, expand=True)
+
+        tk.Label(container, text="Welcome to Kapipang Blends", font=("Helvetica", 16, "bold")).pack(pady=(0, 12))
+
+        form = tk.Frame(container)
+        form.pack(fill=tk.X)
+
+        tk.Label(form, text="Username").grid(row=0, column=0, sticky="w", pady=4)
+        tk.Entry(form, textvariable=self.username_var).grid(row=1, column=0, sticky="ew", pady=(0, 8))
+
+        tk.Label(form, text="Password").grid(row=2, column=0, sticky="w", pady=4)
+        tk.Entry(form, textvariable=self.password_var, show="*").grid(row=3, column=0, sticky="ew", pady=(0, 12))
+
+        form.columnconfigure(0, weight=1)
+
+        tk.Button(container, text="Login", command=self._attempt_login, width=20).pack(pady=(8, 0))
+
+    def _attempt_login(self) -> None:
+        username = self.username_var.get().strip()
+        password = self.password_var.get()
+        if not username or not password:
+            messagebox.showerror("Missing information", "Please enter both username and password.")
+            return
+
+        user = verify_credentials(username, password)
+        if not user:
+            messagebox.showerror("Login failed", "Incorrect username or password.")
+            return
+
+        messagebox.showinfo("Success", f"Logged in as {user.role.title()}.")
+        self.on_success(user)
+        self.destroy()
+
+    def _on_close(self) -> None:
+        if messagebox.askokcancel("Quit", "Do you want to exit the POS system?"):
+            self.master.destroy()


### PR DESCRIPTION
## Summary
- add SQLite database manager that seeds schema for users, sales, inventory, customers, attendance, and activity logs
- introduce authentication helpers with hashed passwords and activity logging utilities
- create Tkinter-based login flow and role-aware dashboard skeleton with placeholders for sales, inventory, reports, attendance, and settings

## Testing
- not run (GUI-based prototype)

------
https://chatgpt.com/codex/tasks/task_e_68db1f3590688320b0b1a68883ba490f